### PR TITLE
Wip card metadata

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -19,8 +19,10 @@ repositories {
 }
 
 dependencies {
+    // checkstyle
     implementation("com.puppycrawl.tools:checkstyle:10.18.2")
 
+    // test
     testImplementation(platform("org.junit:junit-bom:5.10.0"))
     testImplementation("org.junit.jupiter:junit-jupiter")
     testImplementation("org.junit.platform:junit-platform-suite")
@@ -32,6 +34,9 @@ dependencies {
     testImplementation(platform("io.cucumber:cucumber-bom:7.20.1"))
     testImplementation("io.cucumber:cucumber-java")
     testImplementation("io.cucumber:cucumber-junit-platform-engine")
+
+    // fasterxml
+    implementation("com.fasterxml.jackson.core:jackson-databind:2.17.0")
 }
 
 javafx {

--- a/src/main/java/datasource/CardMetadataLoader.java
+++ b/src/main/java/datasource/CardMetadataLoader.java
@@ -1,0 +1,64 @@
+package datasource;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import ui.CardMetadata;
+
+import java.io.InputStream;
+import java.net.URL;
+import java.nio.file.Paths;
+import java.util.Map;
+
+public class CardMetadataLoader implements FileLoader {
+
+	private URL jsonFile;
+	private Map<String, CardMetadata> metadata;
+
+	@Override
+	public boolean open(String fileName) {
+		this.jsonFile = createFilePointer(fileName);
+		this.metadata = loadJson(jsonFile);
+		return true;
+	}
+
+	private URL createFilePointer(String fileName) {
+		URL file = getClass().getResource(fileName);
+		checkFileExistence(file);
+
+		if (!fileName.endsWith(".json")) {
+			throw new IllegalArgumentException(
+					"The requested file is not a .json file"
+			);
+		}
+
+		return file;
+	}
+
+	private void checkFileExistence(URL file) {
+		try {
+			Paths.get(file.toURI());
+		}
+		catch (Exception e) {
+			throw new NullPointerException("The requested file does not exist");
+		}
+	}
+
+	private Map<String, CardMetadata> loadJson(URL file) {
+		try (InputStream is = file.openStream()) {
+			ObjectMapper mapper = new ObjectMapper();
+			return mapper.readValue(is, new TypeReference<>() { });
+		}
+		catch (Exception e) {
+			throw new IllegalStateException("Failed to load card metadata JSON", e);
+		}
+	}
+
+	@Override
+	public URL getFileUrl() {
+		return jsonFile;
+	}
+
+	public Map<String, CardMetadata> getMetadata() {
+		return Map.copyOf(metadata);
+	}
+}

--- a/src/main/java/ui/AssetManager.java
+++ b/src/main/java/ui/AssetManager.java
@@ -14,17 +14,24 @@ public class AssetManager implements AssetProvider {
 
     private final Map<String, Image> images = new HashMap<>();
     private final Map<String, String> svgPaths = new HashMap<>();
+    private final Map<String, CardMetadata> cardMetaData = new HashMap<>();
 
     private String cssUrl;
 
     public void loadGlobalFiles() {
         loadCSS();
         loadImages();
-        loadIcon("restart", "/icons/restart.txt");
-        loadIcon("left-bracket", "/icons/left-bracket.txt");
+        loadIcon("restart",
+                "/icons/restart.txt"
+        );
+        loadIcon("left-bracket",
+                "/icons/left-bracket.txt"
+        );
 
         loadFont("/fonts/koulen-regular.ttf");
         loadFont("/fonts/national-park.ttf");
+
+        loadCardMetadata();
     }
 
     private void loadCSS() {
@@ -55,6 +62,12 @@ public class AssetManager implements AssetProvider {
         Font.loadFont(fontStream, UIConstants.LOADED_FONT_SIZE);
     }
 
+    private void loadCardMetadata() {
+        CardMetadataLoader loader = new CardMetadataLoader();
+        loader.open("/card-metadata.json");
+        cardMetaData.putAll(loader.getMetadata());
+    }
+
     public void addImage(String key, String imageUrl) {
         Image image = new Image(imageUrl);
         images.put(key, image);
@@ -78,6 +91,10 @@ public class AssetManager implements AssetProvider {
 
     public String getStylesheet() {
         return cssUrl;
+    }
+
+    public CardMetadata getCardMetaData(String key) {
+        return cardMetaData.get(key);
     }
 
 }

--- a/src/main/java/ui/CardMetadata.java
+++ b/src/main/java/ui/CardMetadata.java
@@ -1,0 +1,42 @@
+package ui;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class CardMetadata {
+
+	private final String title;
+	private final String subtitle;
+	private final String description;
+	private final String imageUrl;
+
+	@JsonCreator
+	public CardMetadata(
+			@JsonProperty("title") String title,
+			@JsonProperty("subtitle") String subtitle,
+			@JsonProperty("description") String description,
+			@JsonProperty("imageUrl") String imageUrl
+	) {
+		this.title = title;
+		this.subtitle = subtitle;
+		this.description = description;
+		this.imageUrl = imageUrl;
+	}
+
+	public String getTitle() {
+		return title;
+	}
+
+	public String getSubtitle() {
+		return subtitle;
+	}
+
+	public String getDescription() {
+		return description;
+	}
+
+	public String getImageUrl() {
+		return imageUrl;
+	}
+
+}

--- a/src/main/resources/card-metadata.json
+++ b/src/main/resources/card-metadata.json
@@ -1,0 +1,386 @@
+{
+  "EXPLODINGKITTEN_1": {
+    "title": "EXPLODING KITTEN",
+    "subtitle": "",
+    "description": "SHOW THIS CARD IMMEDIATELY.",
+    "imageUrl": "exploding_kitten_1.png"
+  },
+  "EXPLODINGKITTEN_2": {
+    "title": "EXPLODING KITTEN",
+    "subtitle": "",
+    "description": "SHOW THIS CARD IMMEDIATELY.",
+    "imageUrl": "exploding_kitten_2.png"
+  },
+  "EXPLODINGKITTEN_3": {
+    "title": "EXPLODING KITTEN",
+    "subtitle": "",
+    "description": "SHOW THIS CARD IMMEDIATELY.",
+    "imageUrl": "exploding_kitten_3.png"
+  },
+  "DEFUSE_1": {
+    "title": "DEFUSE",
+    "subtitle": "VIA CATNIP SANDWICHES",
+    "description": "PUT YOUR LAST DRAWN CARD BACK INTO THE DECK.",
+    "imageUrl": "defuse_1.png"
+  },
+  "DEFUSE_2": {
+    "title": "DEFUSE",
+    "subtitle": "VIA CRATE",
+    "description": "PUT YOUR LAST DRAWN CARD BACK INTO THE DECK.",
+    "imageUrl": "defuse_2.png"
+  },
+  "DEFUSE_3": {
+    "title": "DEFUSE",
+    "subtitle": "VIA LASER POINTER",
+    "description": "PUT YOUR LAST DRAWN CARD BACK INTO THE DECK.",
+    "imageUrl": "defuse_3.png"
+  },
+  "DEFUSE_4": {
+    "title": "DEFUSE",
+    "subtitle": "VIA MAULING A BABY",
+    "description": "PUT YOUR LAST DRAWN CARD BACK INTO THE DECK.",
+    "imageUrl": "defuse_4.png"
+  },
+  "DEFUSE_5": {
+    "title": "DEFUSE",
+    "subtitle": "VIA SPAY/NEUTER",
+    "description": "PUT YOUR LAST DRAWN CARD BACK INTO THE DECK.",
+    "imageUrl": "defuse_5.png"
+  },
+  "ATTACK_1": {
+    "title": "ATTACK",
+    "subtitle": "WHIP OUT YOUR RUBBER DUCK COLLECTION",
+    "description": "END YOUR TURN WITHOUT DRAWING A CARD. FORCE THE NEXT PLAYER TO TAKE TWO TURNS.",
+    "imageUrl": "attack_1.png"
+  },
+  "ATTACK_2": {
+    "title": "ATTACK",
+    "subtitle": "UNLEASH SOME ADORABLE PENGUIN DIARRHEA",
+    "description": "END YOUR TURN WITHOUT DRAWING A CARD. FORCE THE NEXT PLAYER TO TAKE TWO TURNS.",
+    "imageUrl": "attack_2.png"
+  },
+  "ATTACK_3": {
+    "title": "ATTACK",
+    "subtitle": "RELEASE THE TORTURE BUNNIES",
+    "description": "END YOUR TURN WITHOUT DRAWING A CARD. FORCE THE NEXT PLAYER TO TAKE TWO TURNS.",
+    "imageUrl": "attack_3.png"
+  },
+  "SHUFFLE_1": {
+    "title": "SHUFFLE",
+    "subtitle": "A KRAKEN EMERGES AND HE'S SUPER UPSET",
+    "description": "SHUFFLE THE DRAW PILE.",
+    "imageUrl": "shuffle_1.png"
+  },
+  "SHUFFLE_2": {
+    "title": "SHUFFLE",
+    "subtitle": "A TRANSDIMENSIONAL LITTER BOX MATERIALIZES",
+    "description": "SHUFFLE THE DRAW PILE.",
+    "imageUrl": "shuffle_2.png"
+  },
+  "SHUFFLE_3": {
+    "title": "SHUFFLE",
+    "subtitle": "AN ELECTROMAGNETIC POMERANIAN STORM ROLLS IN FROM THE EAST",
+    "description": "SHUFFLE THE DRAW PILE.",
+    "imageUrl": "shuffle_3.png"
+  },
+  "SHUFFLE_4": {
+    "title": "SHUFFLE",
+    "subtitle": "DISCOVER YOU HAVE A TOILET WEREWOLF",
+    "description": "SHUFFLE THE DRAW PILE.",
+    "imageUrl": "shuffle_4.png"
+  },
+  "SKIP_1": {
+    "title": "SKIP",
+    "subtitle": "COMMANDEER A BUNNYRAPTOR",
+    "description": "END YOUR TURN WITHOUT DRAWING A CARD.",
+    "imageUrl": "skip_1.png"
+  },
+  "SKIP_2": {
+    "title": "SKIP",
+    "subtitle": "CRAB WALK WITH SOME CRABS",
+    "description": "END YOUR TURN WITHOUT DRAWING A CARD.",
+    "imageUrl": "skip_2.png"
+  },
+  "SKIP_3": {
+    "title": "SKIP",
+    "subtitle": "ENGAGE THE HYPERGOAT",
+    "description": "END YOUR TURN WITHOUT DRAWING A CARD.",
+    "imageUrl": "skip_3.png"
+  },
+  "SEETHEFUTURE_1": {
+    "title": "SEE THE FUTURE",
+    "subtitle": "ASK THE ALL-SEEING GOAT WIZARD",
+    "description": "PRIVATELY VIEW THE TOP THREE CARDS OF THE DECK.",
+    "imageUrl": "see_the_future_1.png"
+  },
+  "SEETHEFUTURE_2": {
+    "title": "SEE THE FUTURE",
+    "subtitle": "DEPLOY THE SPECIAL-OPS BUNNIES",
+    "description": "PRIVATELY VIEW THE TOP THREE CARDS OF THE DECK.",
+    "imageUrl": "see_the_future_2.png"
+  },
+  "SEETHEFUTURE_3": {
+    "title": "SEE THE FUTURE",
+    "subtitle": "FEAST UPON A UNICORN ENCHILADA AND GAIN ITS ENCHILADA POWERS",
+    "description": "PRIVATELY VIEW THE TOP THREE CARDS OF THE DECK.",
+    "imageUrl": "see_the_future_3.png"
+  },
+  "SEETHEFUTURE_4": {
+    "title": "SEE THE FUTURE",
+    "subtitle": "RUB THE BELLY OF A PIG-A-CORN",
+    "description": "PRIVATELY VIEW THE TOP THREE CARDS OF THE DECK.",
+    "imageUrl": "see_the_future_4.png"
+  },
+  "NOPE_1": {
+    "title": "NOPE",
+    "subtitle": "A JACKANOPE BOUNDS INTO THE ROOM",
+    "description": "STOP THE ACTION OF ANOTHER PLAYER. YOU CAN PLAY THIS ANY TIME.",
+    "imageUrl": "nope_1.png"
+  },
+  "NOPE_2": {
+    "title": "NOPE",
+    "subtitle": "THE POPE OF NOPE HAS SPOKEN",
+    "description": "STOP THE ACTION OF ANOTHER PLAYER. YOU CAN PLAY THIS ANY TIME.",
+    "imageUrl": "nope_2.png"
+  },
+  "NOPE_3": {
+    "title": "NOPE",
+    "subtitle": "WIN THE NOPEBELL PEACE PRIZE",
+    "description": "STOP THE ACTION OF ANOTHER PLAYER. YOU CAN PLAY THIS ANY TIME.",
+    "imageUrl": "nope_3.png"
+  },
+  "NOPE_4": {
+    "title": "NOPE",
+    "subtitle": "A NOPE NINJA DELIVERS A WICKED DRAGON KICK",
+    "description": "STOP THE ACTION OF ANOTHER PLAYER. YOU CAN PLAY THIS ANY TIME.",
+    "imageUrl": "nope_4.png"
+  },
+  "CATCARD_11": {
+    "title": "HAIRY POTATO CAT",
+    "subtitle": "",
+    "description": "THIS IS A CAT CARD AND IS POWERLESS ON ITS OWN.",
+    "imageUrl": "cat_card_1.png"
+  },
+  "CATCARD_12": {
+    "title": "HAIRY POTATO CAT",
+    "subtitle": "",
+    "description": "THIS IS A CAT CARD AND IS POWERLESS ON ITS OWN.",
+    "imageUrl": "cat_card_1.png"
+  },
+  "CATCARD_13": {
+    "title": "HAIRY POTATO CAT",
+    "subtitle": "",
+    "description": "THIS IS A CAT CARD AND IS POWERLESS ON ITS OWN.",
+    "imageUrl": "cat_card_1.png"
+  },
+  "CATCARD_14": {
+    "title": "HAIRY POTATO CAT",
+    "subtitle": "",
+    "description": "THIS IS A CAT CARD AND IS POWERLESS ON ITS OWN.",
+    "imageUrl": "cat_card_1.png"
+  },
+  "CATCARD_21": {
+    "title": "KIT-TEA-CAT",
+    "subtitle": "",
+    "description": "THIS IS A CAT CARD AND IS POWERLESS ON ITS OWN.",
+    "imageUrl": "cat_card_2.png"
+  },
+  "CATCARD_22": {
+    "title": "KIT-TEA-CAT",
+    "subtitle": "",
+    "description": "THIS IS A CAT CARD AND IS POWERLESS ON ITS OWN.",
+    "imageUrl": "cat_card_2.png"
+  },
+  "CATCARD_23": {
+    "title": "KIT-TEA-CAT",
+    "subtitle": "",
+    "description": "THIS IS A CAT CARD AND IS POWERLESS ON ITS OWN.",
+    "imageUrl": "cat_card_2.png"
+  },
+  "CATCARD_24": {
+    "title": "KIT-TEA-CAT",
+    "subtitle": "",
+    "description": "THIS IS A CAT CARD AND IS POWERLESS ON ITS OWN.",
+    "imageUrl": "cat_card_2.png"
+  },
+  "CATCARD_31": {
+    "title": "RAINBOW-RALPHING CAT",
+    "subtitle": "",
+    "description": "THIS IS A CAT CARD AND IS POWERLESS ON ITS OWN.",
+    "imageUrl": "cat_card_3.png"
+  },
+  "CATCARD_32": {
+    "title": "RAINBOW-RALPHING CAT",
+    "subtitle": "",
+    "description": "THIS IS A CAT CARD AND IS POWERLESS ON ITS OWN.",
+    "imageUrl": "cat_card_3.png"
+  },
+  "CATCARD_33": {
+    "title": "RAINBOW-RALPHING CAT",
+    "subtitle": "",
+    "description": "THIS IS A CAT CARD AND IS POWERLESS ON ITS OWN.",
+    "imageUrl": "cat_card_3.png"
+  },
+  "CATCARD_34": {
+    "title": "RAINBOW-RALPHING CAT",
+    "subtitle": "",
+    "description": "THIS IS A CAT CARD AND IS POWERLESS ON ITS OWN.",
+    "imageUrl": "cat_card_3.png"
+  },
+  "CATCARD_41": {
+    "title": "TROLL CAT",
+    "subtitle": "",
+    "description": "THIS IS A CAT CARD AND IS POWERLESS ON ITS OWN.",
+    "imageUrl": "cat_card_4.png"
+  },
+  "CATCARD_42": {
+    "title": "TROLL CAT",
+    "subtitle": "",
+    "description": "THIS IS A CAT CARD AND IS POWERLESS ON ITS OWN.",
+    "imageUrl": "cat_card_4.png"
+  },
+  "CATCARD_43": {
+    "title": "TROLL CAT",
+    "subtitle": "",
+    "description": "THIS IS A CAT CARD AND IS POWERLESS ON ITS OWN.",
+    "imageUrl": "cat_card_4.png"
+  },
+  "CATCARD_44": {
+    "title": "TROLL CAT",
+    "subtitle": "",
+    "description": "THIS IS A CAT CARD AND IS POWERLESS ON ITS OWN.",
+    "imageUrl": "cat_card_4.png"
+  },
+  "CATOMICBOMB_1": {
+    "title": "CATOMIC BOMB",
+    "subtitle": "THIS IS A CAUSE FOR ALARM",
+    "description": "REMOVE THE EXPLODING KITTENS FROM THE DECK. SHUFFLE THE DECK. PUT ALL THOSE KITTENS FACE DOWN ON TOP. YOUR TURN ENDS AFTER PLAYING THIS CARD.",
+    "imageUrl": "catomic_bomb.png"
+  },
+  "RAISINGHECK_1": {
+    "title": "RAISING HECK",
+    "subtitle": "RAISE A DEMON",
+    "description": "DRAW THE BOTTOM CARD FROM THE DRAW PILE. LOOK AT IT, AND EITHER KEEP IT OR PUT IT ON THE TOP OF THE DRAW PILE. THIS ENDS YOUR TURN.",
+    "imageUrl": "raising_heck_1.png"
+  },
+  "RAISINGHECK_2": {
+    "title": "RAISING HECK",
+    "subtitle": "RAISE THAT FLUSHED GOLDFISH FROM LONG AGO",
+    "description": "DRAW THE BOTTOM CARD FROM THE DRAW PILE. LOOK AT IT, AND EITHER KEEP IT OR PUT IT ON THE TOP OF THE DRAW PILE. THIS ENDS YOUR TURN.",
+    "imageUrl": "raising_heck_2.png"
+  },
+  "GODCAT_1": {
+    "title": "GODCAT",
+    "subtitle": "THE BEST OF THE BLESSED",
+    "description": "PLAY AS ANY CARD IN THE GAME, EXCEPT A NOPE. AFTER PLAYING GODCAT, PUT IT BACK ON THE PLAYMAT.",
+    "imageUrl": "godcat_1.png"
+  },
+  "CLONE_1": {
+    "title": "CLONE",
+    "subtitle": "FIND A PAIR OF NOSFERA-TWOS",
+    "description": "WHEN YOU PLAY THIS CARD, IT BECOMES WHATEVER CARD IS BENEATH IT.",
+    "imageUrl": "clone_1.png"
+  },
+  "CLONE_2": {
+    "title": "CLONE",
+    "subtitle": "MAKE YOUR VOODOO DOLLS DO ALL THE DIRTY WORK",
+    "description": "WHEN YOU PLAY THIS CARD, IT BECOMES WHATEVER CARD IS BENEATH IT.",
+    "imageUrl": "clone_2.png"
+  },
+  "CLONE_3": {
+    "title": "CLONE",
+    "subtitle": "WORK OUT THE KINKS LATER",
+    "description": "WHEN YOU PLAY THIS CARD, IT BECOMES WHATEVER CARD IS BENEATH IT.",
+    "imageUrl": "clone_3.png"
+  },
+  "SWAPTOPANDBOTTOM_1": {
+    "title": "SWAP TOP AND BOTTOM",
+    "subtitle": "MAKE SOME POOR MEDICAL DECISIONS",
+    "description": "SWAP THE TOP AND BOTTOM CARDS OF THE DRAW PILE.",
+    "imageUrl": "swap_top_and_bottom_1.png"
+  },
+  "SWAPTOPANDBOTTOM_2": {
+    "title": "SWAP TOP AND BOTTOM",
+    "subtitle": "EXPERIMENT ON FRANKENCAT",
+    "description": "SWAP THE TOP AND BOTTOM CARDS OF THE DRAW PILE.",
+    "imageUrl": "swap_top_and_bottom_2.png"
+  },
+  "SWAPTOPANDBOTTOM_3": {
+    "title": "SWAP TOP AND BOTTOM",
+    "subtitle": "POISON YOUR NEMESIS",
+    "description": "SWAP THE TOP AND BOTTOM CARDS OF THE DRAW PILE.",
+    "imageUrl": "swap_top_and_bottom_3.png"
+  },
+  "DRAWFROMTHEBOTTOM_1": {
+    "title": "DRAW FROM THE BOTTOM",
+    "subtitle": "TAKE A BIG BITE OF YOUR COWARD SANDWICH",
+    "description": "END YOUR TURN BY DRAWING THE CARD AT THE BOTTOM OF THE DRAW PILE.",
+    "imageUrl": "draw_from_the_bottom_1.png"
+  },
+  "DRAWFROMTHEBOTTOM_2": {
+    "title": "DRAW FROM THE BOTTOM",
+    "subtitle": "PLAY A LEGENDARY JENGA MOVE",
+    "description": "END YOUR TURN BY DRAWING THE CARD AT THE BOTTOM OF THE DRAW PILE.",
+    "imageUrl": "draw_from_the_bottom_2.png"
+  },
+  "DRAWFROMTHEBOTTOM_3": {
+    "title": "DRAW FROM THE BOTTOM",
+    "subtitle": "INVENT A NEW ART FORM",
+    "description": "END YOUR TURN BY DRAWING THE CARD AT THE BOTTOM OF THE DRAW PILE.",
+    "imageUrl": "draw_from_the_bottom_3.png"
+  },
+  "TARGETEDATTACK_1": {
+    "title": "TARGETED ATTACK",
+    "subtitle": "DEPLOY THE GROIN-KICKING PANDA BEAR",
+    "description": "END YOUR TURN WITHOUT DRAWING A CARD. FORCE THE PLAYER OF YOUR CHOICE TO TAKE 2 TURNS. PLAY CONTINUES FROM THAT PLAYER.",
+    "imageUrl": "targeted_attack_1.png"
+  },
+  "TARGETEDATTACK_2": {
+    "title": "TARGETED ATTACK",
+    "subtitle": "FIRE THE FAT-HAMPSTER CATAPULT",
+    "description": "END YOUR TURN WITHOUT DRAWING A CARD. FORCE THE PLAYER OF YOUR CHOICE TO TAKE 2 TURNS. PLAY CONTINUES FROM THAT PLAYER.",
+    "imageUrl": "targeted_attack_2.png"
+  },
+  "TARGETEDATTACK_3": {
+    "title": "TARGETED ATTACK",
+    "subtitle": "UNLEASH A SHARK WHO HURTS WITH WORDS INSTEAD OF TEETH",
+    "description": "END YOUR TURN WITHOUT DRAWING A CARD. FORCE THE PLAYER OF YOUR CHOICE TO TAKE 2 TURNS. PLAY CONTINUES FROM THAT PLAYER.",
+    "imageUrl": "targeted_attack_3.png"
+  },
+  "TARGETEDATTACK_4": {
+    "title": "TARGETED ATTACK",
+    "subtitle": "UNLEASH THE RUNNING PIRANHA",
+    "description": "END YOUR TURN WITHOUT DRAWING A CARD. FORCE THE PLAYER OF YOUR CHOICE TO TAKE 2 TURNS. PLAY CONTINUES FROM THAT PLAYER.",
+    "imageUrl": "targeted_attack_4.png"
+  },
+  "WINNERWINNERCATNIPDINNER_1": {
+    "title": "WINNER WINNER CATNIP DINNER",
+    "subtitle": "GET TEN BOXES FROM COSTCO",
+    "description": "IF YOU HOLD THIS CARD FOR 4 FULL ROUNDS, YOU AUTOMATICALLY WIN.",
+    "imageUrl": "winner_winner_catnip_dinner_1.png"
+  },
+  "RAGEBAIT_1": {
+    "title": "RAGEBAIT",
+    "subtitle": "GO FISHING ON AN ANGRY STOMACH",
+    "description": "SWITCH HANDS WITH A PLAYER OF YOUR CHOICE.",
+    "imageUrl": "ragebait_1.png"
+  },
+  "RECYCLE_1": {
+    "title": "RECYCLE",
+    "subtitle": "THROW DOG POOP IN YOUR NEIGHBOR'S RECYCLING BIN",
+    "description": "SHUFFLE THE DISCARD PILE. DRAW THE BOTTOM CARD TO TAKE ONE TURN.",
+    "imageUrl": "recycle_1.png"
+  },
+  "DOUBLEUP_1": {
+    "title": "DOUBLE UP",
+    "subtitle": "SPLURGE AT IN-N-OUT",
+    "description": "DRAW AN EXTRA CARD AT THE END OF YOUR TURN.",
+    "imageUrl": "double_up_1.png"
+  },
+  "CLEANUP_1": {
+    "title": "CLEAN UP",
+    "subtitle": "RELEASE THE CLEANING GOATS",
+    "description": "DRAW AN EXTRA CARD AT THE END OF YOUR TURN.",
+    "imageUrl": "clean_up_1.png"
+  }
+}


### PR DESCRIPTION
Every card in Exploding Kittens has a unique combination of title, subtitle, description, and image. This pr includes a CardMetadata class (with title, subtitle, description, imageUrl) that the UI can use to display. A HashMap that maps a card's id to its corresponding CardMetadata instance is added in AssetManager, and is populated (and can be accessed just like the images and svgPath hashmaps) when all other fonts/images/stylesheet/icons are loaded.